### PR TITLE
pass through _form and validate to component

### DIFF
--- a/packages/redux-forms/src/shared/fieldProps.ts
+++ b/packages/redux-forms/src/shared/fieldProps.ts
@@ -71,10 +71,8 @@ export type MetaProp =
 const IGNORE_PROPS = [
   ...INPUT_PROPS,
   ...META_PROPS,
-  'validate',
   'normalize',
   'defaultValue',
-  '_form',
   '_addField',
   '_fieldChange',
   '_fieldFocus',


### PR DESCRIPTION
If i have these fields in my component, I can dispatch fieldError and handle more complex validation :)

not sure if this breaks tests, but it worked for me locally with initial test